### PR TITLE
Do not use central package management for this subrepo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Jeg innfører sentral styring av avhengigheter for Minside. For å ikke ødelegge eksisterende builds legger jeg til denne filen. I fremtiden kan vi gjøre slik at dette repoet blir avhengig av pakkene til prosjektene der det brukes.
